### PR TITLE
Support css @rules without block (like `@import`)

### DIFF
--- a/pyaco-validate/src/lib.rs
+++ b/pyaco-validate/src/lib.rs
@@ -90,7 +90,7 @@ pub async fn run(options: Options) -> Result<()> {
         .collect::<HashSet<&String>>();
 
     info!(
-        "{} classes used in total throughout the project, {} classes are whitelisted",
+        "{} classes used in total in the provided files, {} whitelisted classes",
         found_classes.len(),
         accepted_classes.len()
     );


### PR DESCRIPTION
Closes https://github.com/scoville/tailwind-generator/issues/48

While at it I also cleanup some code and improved the error reporting.